### PR TITLE
Rubygems 1.3.7 compatibility

### DIFF
--- a/lib/chef-handler-graphite.rb
+++ b/lib/chef-handler-graphite.rb
@@ -32,7 +32,13 @@ class GraphiteReporting < Chef::Handler
   end
 
   def report
-    Chef::Log.debug("#{Gem::Specification.find_by_name('chef-handler-graphite').full_name} loaded as a handler.")
+    gemspec = if Gem::Specification.respond_to? :find_by_name
+      Gem::Specification.find_by_name('chef-handler-graphite')
+    else
+      Gem::SourceIndex.find_name('chef-handler-graphite').last
+    end
+
+    Chef::Log.debug("#{gemspec.full_name} loaded as a handler.")
 
     g = Graphite.new
     g.host = @graphite_host


### PR DESCRIPTION
Opscode's Omnibus Chef full stack installer currently uses Rubygems 1.3.7 which doesn't work with some of the code currently in chef-handler-graphite. This patch works around that.
