### PR TITLE
Rubygems 1.3.7 compatibility

### DIFF
--- a/lib/chef-handler-graphite.rb
+++ b/lib/chef-handler-graphite.rb
@@ -32,7 +32,13 @@ class GraphiteReporting < Chef::Handler
   end
 
   def report
-    Chef::Log.debug("#{Gem::Specification.find_by_name('chef-handler-graphite').full_name} loaded as a handler.")
+    gemspec = if Gem::Specification.respond_to? :find_by_name
+      Gem::Specification.find_by_name('chef-handler-graphite')
+    else
+      Gem.source_index.find_name('chef-handler-graphite').last
+    end
+
+    Chef::Log.debug("#{gemspec.full_name} loaded as a handler.")
 
     g = Graphite.new
     g.host = @graphite_host


### PR DESCRIPTION
Opscode's Omnibus Chef full stack installer embeds Rubygems 1.3.7, which doesn't have `Gem::Specification.find_by_name` so chef-handler-graphite doesn't currently work with it.

This patch falls back to the older, deprecated method when the newer method doesn't exist.
