### PR TITLE
Don't rely on the Gem environment

### DIFF
--- a/chef-handler-graphite.gemspec
+++ b/chef-handler-graphite.gemspec
@@ -1,24 +1,24 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+require File.expand_path('../lib/chef-handler-graphite/version', __FILE__)
 
-Gem::Specification.new do |s|
-  s.name        = "chef-handler-graphite"
-  s.version     = "1.0.0"
-  s.authors     = ["Ian Meyer"]
-  s.email       = ["ianmmeyer@gmail.com"]
-  s.homepage    = ""
-  s.summary     = %q{Push reporting stats to Graphite}
-  s.description = %q{Push reporting stats to Graphite}
+Gem::Specification.new do |gem|
+  gem.name        = "chef-handler-graphite"
+  gem.version     = ChefHandlerGraphite::VERSION
+  gem.authors     = ["Ian Meyer"]
+  gem.email       = ["ianmmeyer@gmail.com"]
+  gem.homepage    = "https://github.com/imeyer/chef-handler-graphite"
+  gem.summary     = %q{Push reporting stats to Graphite}
+  gem.description = %q{Push reporting stats to Graphite}
 
-  s.rubyforge_project = "chef-handler-graphite"
+  gem.rubyforge_project = "chef-handler-graphite"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  gem.files         = `git ls-files`.split($\)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_development_dependency "simple-graphite"
-  s.add_runtime_dependency "simple-graphite"
-  s.add_runtime_dependency "chef"
+  gem.add_development_dependency "simple-graphite"
+  gem.add_runtime_dependency "simple-graphite"
+  gem.add_runtime_dependency "chef"
 end

--- a/lib/chef-handler-graphite.rb
+++ b/lib/chef-handler-graphite.rb
@@ -21,6 +21,7 @@ Gem.clear_paths
 require "simple-graphite"
 require "chef"
 require "chef/handler"
+require "chef-handler-graphite/version"
 
 class GraphiteReporting < Chef::Handler
   attr_writer :metric_key, :graphite_host, :graphite_port
@@ -32,13 +33,7 @@ class GraphiteReporting < Chef::Handler
   end
 
   def report
-    gemspec = if Gem::Specification.respond_to? :find_by_name
-      Gem::Specification.find_by_name('chef-handler-graphite')
-    else
-      Gem.source_index.find_name('chef-handler-graphite').last
-    end
-
-    Chef::Log.debug("#{gemspec.full_name} loaded as a handler.")
+    Chef::Log.debug("chef-handler-graphite-#{ChefHandlerGraphite::VERSION} loaded as a handler.")
 
     g = Graphite.new
     g.host = @graphite_host

--- a/lib/chef-handler-graphite/version.rb
+++ b/lib/chef-handler-graphite/version.rb
@@ -1,0 +1,3 @@
+module ChefHandlerGraphite
+  VERSION = "1.2.0"
+end


### PR DESCRIPTION
The gem environment with Chef's Omnibus-generated packages is dicey, best to not depend on it. I'm experiencing a failure to find the chef-handle-graphite gem within the report method even though the handler code is running from within the gem.
