### PR TITLE
Resiliency fix

### DIFF
--- a/lib/chef-handler-graphite.rb
+++ b/lib/chef-handler-graphite.rb
@@ -45,8 +45,8 @@ class GraphiteReporting < Chef::Handler
     g.port = @graphite_port
 
     metrics = Hash.new
-    metrics[:updated_resources] = run_status.updated_resources.length
-    metrics[:all_resources] = run_status.all_resources.length
+    metrics[:updated_resources] = run_status.updated_resources.length if run_status.updated_resources
+    metrics[:all_resources] = run_status.all_resources.length if run_status.all_resources
     metrics[:elapsed_time] = run_status.elapsed_time
 
     if run_status.success?


### PR DESCRIPTION
Added if-guards when getting length of certain run_status fields. This is needed because they may be nil if the chef run fails early enough. And this causes the length call to thrown and exception.
