### PR TITLE
Allow to add user metrics via run_context

### DIFF
--- a/lib/chef-handler-graphite.rb
+++ b/lib/chef-handler-graphite.rb
@@ -57,6 +57,10 @@ class GraphiteReporting < Chef::Handler
       metrics[:fail] = 1
     end
 
+    # user provided metrics
+    user_metrics = run_status.run_context['graphite-handler-metrics']
+    metrics.merge!(user_metrics) if user_metrics.is_a?(Hash)
+
     g.push_to_graphite do |graphite|
       metrics.each do |metric, value|
         Chef::Log.debug("#{@metric_key}.#{metric} #{value} #{g.time_now}")


### PR DESCRIPTION
Using run_context, users are able to add metrics sent via the
chef_handler.
It will help to count various event (ignored failures) or measure
specific resource execution (disk format).

Fix #6
