### PR TITLE
Allow options to be given with key as string

### DIFF
--- a/lib/chef-handler-graphite.rb
+++ b/lib/chef-handler-graphite.rb
@@ -26,9 +26,9 @@ class GraphiteReporting < Chef::Handler
   attr_writer :metric_key, :graphite_host, :graphite_port
 
   def initialize(options = {})
-    @metric_key = options[:metric_key]
-    @graphite_host = options[:graphite_host]
-    @graphite_port = options[:graphite_port]
+    @metric_key = options[:metric_key] || options["metric_key"]
+    @graphite_host = options[:graphite_host] || options["graphite_host"]
+    @graphite_port = options[:graphite_port] || options["graphite_port"]
   end
 
   def report


### PR DESCRIPTION
Latest chef-client cookbook have a new way to add handlers to the `client.rb` configuration, but when setting arguments for the handler initializer, the keys are transformed to string.
