### PR TITLE
Properly catch error while talking to graphite

### DIFF
--- a/lib/chef-handler-graphite.rb
+++ b/lib/chef-handler-graphite.rb
@@ -60,7 +60,11 @@ class GraphiteReporting < Chef::Handler
     g.push_to_graphite do |graphite|
       metrics.each do |metric, value|
         Chef::Log.debug("#{@metric_key}.#{metric} #{value} #{g.time_now}")
-        graphite.puts "#{@metric_key}.#{metric} #{value} #{g.time_now}"
+        begin
+          graphite.puts "#{@metric_key}.#{metric} #{value} #{g.time_now}"
+        rescue SocketError => e
+          Chef::Log.warn("Impossible to push metric because of #{e.class.name} #{e.message}")
+        end
       end
     end
   end


### PR DESCRIPTION
Even though chef catches errors in report handler, this generates a
large frightening stacktrace.

This simple warn is less scary for users

Change-Id: Ia2040489c706230a35f373b2097a725ff6b7a65f